### PR TITLE
fix(ci): always run release cleanup on failure

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -514,7 +514,7 @@ jobs:
                   pnpm publish --provenance --access public --no-git-checks
 
             - name: Cleanup on failure
-              if: failure() && steps.create_release.outcome == 'success'
+              if: failure()
               env:
                   RELEASE_VERSION: ${{ steps.version.outputs.new_version }}
                   GITHUB_TOKEN: ${{ secrets.ACTIONS_KEY }}
@@ -526,9 +526,9 @@ jobs:
                   fi
 
                   # Proceed with cleanup only if validation passes
-                  gh release delete "$RELEASE_VERSION" --yes
-                  git tag -d "$RELEASE_VERSION"
-                  git push --delete origin "$RELEASE_VERSION"
+                  gh release delete "$RELEASE_VERSION" --yes || true
+                  git tag -d "$RELEASE_VERSION" || true
+                  git push --delete origin "$RELEASE_VERSION" || true
 
             - name: Notify on failure
               if: failure()


### PR DESCRIPTION
## Problem

In `.github/workflows/npm-publish.yml`, the **Cleanup on failure** step is gated on:

```yaml
if: failure() && steps.create_release.outcome == 'success'
```

The version-bump step pushes the commit and tag *before* the release step runs. If `gh release create` itself fails, this cleanup is **skipped** (its condition requires `create_release` to have succeeded), so the branch/tag are left ahead of npm/GitHub Releases — a partial-release state that needs manual repair.

## Fix

```diff
- if: failure() && steps.create_release.outcome == 'success'
+ if: failure()
...
-   gh release delete "$RELEASE_VERSION" --yes
-   git tag -d "$RELEASE_VERSION"
-   git push --delete origin "$RELEASE_VERSION"
+   gh release delete "$RELEASE_VERSION" --yes || true
+   git tag -d "$RELEASE_VERSION" || true
+   git push --delete origin "$RELEASE_VERSION" || true
```

- `if: failure()` ensures cleanup always runs when the job fails, including when `gh release create` is the thing that failed.
- The `|| true` guards keep one already-missing artifact (e.g. a release that never got created) from aborting the remaining cleanup commands.

## Context

Originally flagged by CodeRabbit on `humanspeak/svelte-purify#56` and fixed there. This same templated workflow carries the bug across the org; this PR applies the identical fix here. Verified the change is exactly the condition line plus the three cleanup commands — no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
