### PR TITLE
ci: standardize workflow validation

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,8 +1,8 @@
 name: Validate Workflows
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read # required for actions/checkout
+    pull-requests: read # only needed for fork PRs
 
 on:
     pull_request:
@@ -21,7 +21,7 @@ jobs:
                   fetch-depth: 0 # Fetch full history for git comparisons
 
             - name: Set up Python
-              uses: actions/setup-python@v5 # zizmor: ignore[unpinned-uses]
+              uses: actions/setup-python@v6 # zizmor: ignore[unpinned-uses]
               with:
                   python-version: '3.12'
 
@@ -138,7 +138,7 @@ jobs:
                       else
                           echo "::warning::Cannot find base ref ${BASE_REF} in any form"
                           echo "Falling back to validating all workflow files"
-                          changed_files=$(find . -name "*.yml" -o -name "*.yaml" | sed 's|^\./||' || true)
+                          changed_files=$(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) || true)
                       fi
                   fi
 
@@ -188,7 +188,7 @@ jobs:
 
             - name: Upload zizmor logs
               if: always()
-              uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+              uses: actions/upload-artifact@v7 # zizmor: ignore[unpinned-uses]
               with:
                   name: zizmor-logs
                   path: ${{ github.workspace }}/zizmor-logs


### PR DESCRIPTION
## Summary

Standardizes `.github/workflows/validate-workflows.yml` on the validated workflow version used across the repo set.

## Changes

- 🔄 CI/CD
  - Replace the existing workflow validation file with the approved standard version.
  - Use `actions/setup-python@v6` and `actions/upload-artifact@v7` in validation.

## Commits

- [`5f4b216`](https://github.com/humanspeak/svelte-diff-match-patch/commit/5f4b216cc324ab8233f909d54832f001723b7b47) ci: standardize workflow validation
