### PR TITLE
ci(npm-publish): refresh README ecosystem footer + fix pnpm-11 version bump

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -460,16 +460,33 @@ jobs:
                       ;;
                   esac
 
-                  # Get the new version number
-                  NEW_VERSION=$(pnpm version "$BUMP_TYPE" --no-git-tag-version)
-                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  # Mutate package.json only — do NOT parse pnpm stdout (pnpm 11 prints multi-line text)
+                  pnpm version "$BUMP_TYPE" --no-git-tag-version
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  NEW_VERSION="v${PACKAGE_VERSION}"
+                  echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
                   # Escape special characters in PR title and URL
                   ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[`$"\]/\\&/g')
                   ESCAPED_URL=$(echo "$PR_URL" | sed 's/[`$"\]/\\&/g')
 
-                  # Commit the version changes
-                  git add package.json
+                  # Refresh the managed README footer (the docs-kit ecosystem block +
+                  # standardized License/Credits). Runs AFTER `pnpm version` so the
+                  # working tree is clean when pnpm runs — pnpm version aborts on a
+                  # dirty tree. Fetched raw from the private docs-kit repo (no install,
+                  # no dependency here); reuses $GITHUB_TOKEN (ACTIONS_KEY) for auth.
+                  # Best-effort: a failed fetch or roster blip only warns.
+                  UPDATER="$RUNNER_TEMP/update-ecosystem-readme.mjs"
+                  if curl -fsSL -H "Authorization: token $GITHUB_TOKEN" \
+                      https://raw.githubusercontent.com/humanspeak/docs-kit/main/scripts/update-ecosystem-readme.mjs \
+                      -o "$UPDATER"; then
+                      node "$UPDATER" || echo "::warning::ecosystem updater errored; README left unchanged"
+                  else
+                      echo "::warning::could not fetch ecosystem updater; skipping README refresh"
+                  fi
+
+                  # Commit the version changes (and any refreshed README ecosystem block)
+                  git add package.json README.md
                   git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
 
                   # Create an annotated tag with release notes


### PR DESCRIPTION
## What

1. **Fixes the pnpm-11 version-bump bug.** This repo derived `NEW_VERSION=$(pnpm version …)` by parsing stdout — pnpm 11 prints multi-line text, so the captured version is garbage. Switched to the safe pattern: `pnpm version --no-git-tag-version` then read the version via `node -p`.
2. **Adds the README ecosystem-footer refresh** (after `pnpm version`, before the commit) — same as the rest of the fleet.

No new dependency: the updater is `curl`ed raw from the private docs-kit repo and run with `node`. Best-effort — a failed fetch only warns, never fails the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)