### PR TITLE
ci(npm-publish): add environment: production to publish job (fix OIDC ENEEDAUTH)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -307,6 +307,7 @@ jobs:
         needs: [check-if-merged, build, playwright-tests, coverage-report]
         if: needs.check-if-merged.outputs.should_run == 'true'
         runs-on: ubuntu-latest
+        environment: production
         permissions:
             contents: write
             packages: write


### PR DESCRIPTION
## Problem

Publish run [28196102507](https://github.com/humanspeak/svelte-diff-match-patch/actions/runs/28196102507) built the tarball, bumped the version, and created the release — then **`Publish` failed** with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

## Root cause

The npm **Trusted Publisher** for this package is configured for the **`production`** environment (Settings → Trusted Publisher: `npm-publish.yml`, env `production`). But the `publish-github-packages` job was **missing `environment: production`**, so the OIDC token GitHub minted carried no matching environment claim and npm rejected the trusted publish.

This was config drift — **every other repo in the fleet already declares `environment: production`** on its publish job; this is the only one that didn't.

## Fix

Add `environment: production` to the `publish-github-packages` job (one line). No other change.

## Note

`main` already has a `Bump version to v0.1.3` commit from the failed run (the README ecosystem footer landed fine). The failed run's cleanup removed the git tag + GitHub release but not the commit, so the next successful publish will land as `0.1.4` and `0.1.3` will be skipped on npm — harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)