### PR TITLE
ci: drop Node 20 + add environment: production to publish job (fix OIDC)

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         strategy:
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
         steps:
             - name: Checkout
               uses: actions/checkout@v6 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -200,7 +200,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         strategy:
             matrix:
-                node-version: [20, 22, 24]
+                node-version: [22, 24]
         permissions:
             contents: read
             packages: write

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -307,6 +307,7 @@ jobs:
         needs: [check-if-merged, build, playwright-tests, coverage-report]
         if: needs.check-if-merged.outputs.should_run == 'true'
         runs-on: ubuntu-latest
+        environment: production
         permissions:
             contents: write
             packages: write


### PR DESCRIPTION
## What

Two CI fixes for this repo, bundled:

1. **Drop Node 20 from the CI matrix** (`node-version: [20, 22, 24]` → `[22, 24]` in `npm-publish.yml` + `coveralls.yml`). Node 20 is EOL and the pinned `pnpm` no longer supports it (`ERR_PNPM_UNSUPPORTED_ENGINE`). Keep 22 + 24.
2. **Add `environment: production` to the publish job.** The npm Trusted Publisher for `@humanspeak/svelte-diff-match-patch` is scoped to the `production` environment, but the `publish-github-packages` job did not declare it — so the OIDC token carried no matching environment claim and npm rejected the publish with `ENEEDAUTH` ([run 28196102507](https://github.com/humanspeak/svelte-diff-match-patch/actions/runs/28196102507)). Every other repo in the fleet already sets this.

## Note

`main` already has a `Bump version to v0.1.3` commit from the failed run (the README ecosystem footer landed fine; only npm publish failed). The next successful publish will land as `0.1.4`, skipping `0.1.3` on npm — harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)